### PR TITLE
[incidents] add support for incidents endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/effxhq/go-datadog-api
+
+go 1.13
+
+require (
+	github.com/cenkalti/backoff v1.0.1-0.20161020194410-b02f2bbce11d
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2
+	github.com/zorkian/go-datadog-api v2.29.0+incompatible
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cenkalti/backoff v1.0.1-0.20161020194410-b02f2bbce11d h1:7WWHP1KWOsP+Sis6OtOhQrgiEjDRYbggsfK5YWmsQho=
+github.com/cenkalti/backoff v1.0.1-0.20161020194410-b02f2bbce11d/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/zorkian/go-datadog-api v2.29.0+incompatible h1:uZZg0POZ6tLmVFtjUSaTZYwR6Q6RrHx6f/blTEDn8dA=
+github.com/zorkian/go-datadog-api v2.29.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=

--- a/incidents.go
+++ b/incidents.go
@@ -1,0 +1,92 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2013 by authors and contributors.
+ */
+
+package datadog
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type IncidentUser struct {
+	Data struct {
+		Attributes struct {
+			Email string `json:"email,omitempty"`
+			Name  string `json:"name,omitempty"`
+		}
+		ID   string `json:"id,omitempty"`
+		Type string `json:"type,omitempty"`
+	}
+}
+
+type Attributes struct {
+	Commander        IncidentUser `json:"commander,omitempty"`
+	CreatedBy        IncidentUser `json:"created_by,omitempty"`
+	LastModifiedBy   IncidentUser `json:"last_modified_by,omitempty"`
+	CreatedAt        string       `json:"created,omitempty"`
+	ResolvedAt       string       `json:"resolved,omitempty"`
+	ModifiedAt       string       `json:"modified,omitempty"`
+	DetectedAt       string       `json:"detected,omitempty"`
+	State            string       `json:"state,omitempty"`
+	Title            string       `json:"title,omitempty"`
+	Severity         string       `json:"severity,omitempty"`
+	PostmortemId     string       `json:"postmortem_id,omitempty"`
+	CustomerImpacted bool         `json:"customer_impacted,omitempty"`
+}
+
+type IncidentQueryOpts struct {
+	Include    string
+	PageSize   int64
+	PageNumber int64
+}
+
+type Incident struct {
+	Attributes Attributes `json:"attributes,omitempty"`
+	ID         string     `json:"id,omitempty"`
+}
+
+type reqIncidents struct {
+	Meta      Meta       `json:"meta,omitempty"`
+	Incidents []Incident `json:"data,omitempty"`
+}
+
+type Meta struct {
+	Pagination struct {
+		Number     int `json:"number,omitempty"`
+		NextNumber int `json:"next_number,omitempty"`
+		Size       int `json:"size,omitempty"`
+	}
+}
+
+func (client *Client) GetIncidentsWithOptions(opts IncidentQueryOpts) ([]Incident, error) {
+	var out reqIncidents
+	var query []string
+	if len(opts.Include) > 0 {
+		value := fmt.Sprintf("include=%s", opts.Include)
+		query = append(query, value)
+	}
+	if opts.PageSize > 0 {
+		value := fmt.Sprintf("page[size]=%d", opts.PageSize)
+		query = append(query, value)
+	}
+	if opts.PageNumber > 0 {
+		value := fmt.Sprintf("page[number]=%d", opts.PageNumber)
+		query = append(query, value)
+	}
+	queryString, err := url.ParseQuery(strings.Join(query, "&"))
+	if err != nil {
+		return nil, err
+	}
+	err = client.doJsonRequest("GET", fmt.Sprintf("/v2/incidents?%v", queryString.Encode()), nil, &out)
+	if err != nil {
+		return nil, err
+	}
+
+	return out.Incidents, nil
+}


### PR DESCRIPTION
New beta incidents endpoint is available, this gives us the ability to use it.

Example usage of the endpoint results in the following:

```$ go run incident_example.go
2020/08/07 16:13:27 incidents 2
INCIDENT: 0, b0ed1948c02455508726d29053110b54 Datadog test incident
	 COMMANDER: joey@effx.io Joey Parsons
	 CREATED: 2020-08-03T21:14:24.209661+00:00
	 STATE: resolved
	 SEVERITY: SEV-1
INCIDENT: 1, 1865948bd863518faaf3f39774061961 things are bad now
	 COMMANDER: joey@effx.io Joey Parsons
	 CREATED: 2020-08-05T19:23:23.021221+00:00
	 STATE: active
	 SEVERITY: SEV-1
```

Also, this adds go mod support to the repo as it was previously using old vendor functionality.